### PR TITLE
Bump versions manually

### DIFF
--- a/change/@pulumi-facet-e1868a43-c5fe-4234-a5e9-cfe16846358e.json
+++ b/change/@pulumi-facet-e1868a43-c5fe-4234-a5e9-cfe16846358e.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update FAST to latest versions",
-  "packageName": "@pulumi/facet",
-  "email": "c@nunciato.org",
-  "dependentChangeType": "patch"
-}

--- a/packages/facet/CHANGELOG.json
+++ b/packages/facet/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@pulumi/facet",
   "entries": [
     {
+      "date": "Wed, 22 Sep 2021 21:02:32 GMT",
+      "tag": "@pulumi/facet_v0.0.35",
+      "version": "0.0.35",
+      "comments": {
+        "patch": [
+          {
+            "author": "c@nunciato.org",
+            "package": "@pulumi/facet",
+            "comment": "Update FAST to latest versions",
+            "commit": "734d7e350a78471d354ef9465f54c67d7a48b92e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Sun, 19 Sep 2021 01:27:03 GMT",
       "tag": "@pulumi/facet_v0.0.34",
       "version": "0.0.34",

--- a/packages/facet/CHANGELOG.md
+++ b/packages/facet/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @pulumi/facet
 
-This log was last generated on Sun, 19 Sep 2021 01:27:03 GMT and should not be manually modified.
+This log was last generated on Wed, 22 Sep 2021 21:02:32 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.35
+
+Wed, 22 Sep 2021 21:02:32 GMT
+
+### Patches
+
+- Update FAST to latest versions (c@nunciato.org)
 
 ## 0.0.34
 

--- a/packages/facet/package.json
+++ b/packages/facet/package.json
@@ -1,47 +1,47 @@
 {
-    "name": "@pulumi/facet",
-    "version": "0.0.34",
-    "license": "Apache-2.0",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/pulumi/facet.git",
-        "directory": "packages/facet"
-    },
-    "main": "dist/index.js",
-    "unpkg": "dist/facet.min.js",
-    "files": [
-        "dist/**/*"
-    ],
-    "dependencies": {
-        "@microsoft/fast-components": "^2.11.0",
-        "@microsoft/fast-element": "^1.5.1",
-        "@microsoft/fast-foundation": "^2.15.0",
-        "lodash-es": "^4.17.21"
-    },
-    "devDependencies": {
-        "@babel/core": "^7.15.5",
-        "@rollup/plugin-node-resolve": "^13.0.4",
-        "@storybook/addon-essentials": "^6.3.8",
-        "@storybook/builder-webpack5": "^6.3.8",
-        "@storybook/html": "^6.3.8",
-        "@storybook/manager-webpack5": "^6.3.8",
-        "hook-shell-script-webpack-plugin": "^0.1.3",
-        "rollup": "^2.56.3",
-        "rollup-plugin-filesize": "^9.1.1",
-        "rollup-plugin-terser": "^7.0.2",
-        "rollup-plugin-typescript2": "^0.30.0",
-        "style-dictionary": "^3.0.2",
-        "tslib": "^2.0.0",
-        "typescript": "^3.9.0",
-        "webpack": "^5.52.0"
-    },
-    "scripts": {
-        "dev": "tsc --watch",
-        "dev:storybook": "start-storybook -p 4002",
-        "dev:tokens": "webpack --watch",
-        "build": "tsc && rollup -c",
-        "build:tokens-json": "webpack",
-        "build:tokens-public": "style-dictionary build --config ./style.config.js",
-        "build:storybook": "build-storybook"
-    }
+  "name": "@pulumi/facet",
+  "version": "0.0.35",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/pulumi/facet.git",
+    "directory": "packages/facet"
+  },
+  "main": "dist/index.js",
+  "unpkg": "dist/facet.min.js",
+  "files": [
+    "dist/**/*"
+  ],
+  "dependencies": {
+    "@microsoft/fast-components": "^2.11.0",
+    "@microsoft/fast-element": "^1.5.1",
+    "@microsoft/fast-foundation": "^2.15.0",
+    "lodash-es": "^4.17.21"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "@rollup/plugin-node-resolve": "^13.0.4",
+    "@storybook/addon-essentials": "^6.3.8",
+    "@storybook/builder-webpack5": "^6.3.8",
+    "@storybook/html": "^6.3.8",
+    "@storybook/manager-webpack5": "^6.3.8",
+    "hook-shell-script-webpack-plugin": "^0.1.3",
+    "rollup": "^2.56.3",
+    "rollup-plugin-filesize": "^9.1.1",
+    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-typescript2": "^0.30.0",
+    "style-dictionary": "^3.0.2",
+    "tslib": "^2.0.0",
+    "typescript": "^3.9.0",
+    "webpack": "^5.52.0"
+  },
+  "scripts": {
+    "dev": "tsc --watch",
+    "dev:storybook": "start-storybook -p 4002",
+    "dev:tokens": "webpack --watch",
+    "build": "tsc && rollup -c",
+    "build:tokens-json": "webpack",
+    "build:tokens-public": "style-dictionary build --config ./style.config.js",
+    "build:storybook": "build-storybook"
+  }
 }

--- a/sites/facet/CHANGELOG.json
+++ b/sites/facet/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@pulumi/facet-website",
   "entries": [
     {
+      "date": "Wed, 22 Sep 2021 21:02:32 GMT",
+      "tag": "@pulumi/facet-website_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@pulumi/facet-website",
+            "comment": "Bump @pulumi/facet to v0.0.35",
+            "commit": "734d7e350a78471d354ef9465f54c67d7a48b92e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Sun, 19 Sep 2021 01:27:03 GMT",
       "tag": "@pulumi/facet-website_v0.0.1",
       "version": "0.0.1",

--- a/sites/facet/CHANGELOG.md
+++ b/sites/facet/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @pulumi/facet-website
 
-This log was last generated on Sun, 19 Sep 2021 01:27:03 GMT and should not be manually modified.
+This log was last generated on Wed, 22 Sep 2021 21:02:32 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.1
+
+Wed, 22 Sep 2021 21:02:32 GMT
+
+### Patches
+
+- Bump @pulumi/facet to v0.0.35
 
 ## 0.0.1
 

--- a/sites/facet/package.json
+++ b/sites/facet/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/core": "2.0.0-beta.6",
     "@docusaurus/preset-classic": "2.0.0-beta.6",
     "@mdx-js/react": "^1.6.21",
-    "@pulumi/facet": "^0.0.34",
+    "@pulumi/facet": "^0.0.35",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",

--- a/sites/sandbox/CHANGELOG.json
+++ b/sites/sandbox/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@pulumi/facet-sandbox",
   "entries": [
     {
+      "date": "Wed, 22 Sep 2021 21:02:32 GMT",
+      "tag": "@pulumi/facet-sandbox_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@pulumi/facet-sandbox",
+            "comment": "Bump @pulumi/facet to v0.0.35",
+            "commit": "734d7e350a78471d354ef9465f54c67d7a48b92e"
+          }
+        ]
+      }
+    },
+    {
       "date": "Sun, 19 Sep 2021 01:27:03 GMT",
       "tag": "@pulumi/facet-sandbox_v0.0.1",
       "version": "0.0.1",

--- a/sites/sandbox/CHANGELOG.md
+++ b/sites/sandbox/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @pulumi/facet-sandbox
 
-This log was last generated on Sun, 19 Sep 2021 01:27:03 GMT and should not be manually modified.
+This log was last generated on Wed, 22 Sep 2021 21:02:32 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.1
+
+Wed, 22 Sep 2021 21:02:32 GMT
+
+### Patches
+
+- Bump @pulumi/facet to v0.0.35
 
 ## 0.0.1
 

--- a/sites/sandbox/package.json
+++ b/sites/sandbox/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@pulumi/facet": "^0.0.34"
+    "@pulumi/facet": "^0.0.35"
   },
   "devDependencies": {
     "html-webpack-plugin": "^5.3.2",


### PR DESCRIPTION
This change includes the result of running [`beachball bump`](https://microsoft.github.io/beachball/cli/bump.html) locally with what's currently in `master`. Ordinarily, this command runs implicitly with `publish`, but [the last run failed](https://github.com/pulumi/facet/runs/3680150379?check_suite_focus=true#step:5:642) because a previous publish job had only partially completed. This should true things up so that when the next publish job runs, it'll complete as expected. 🤞  (We currently use [beachball](https://microsoft.github.io/beachball/) to make package publishing "easier".)