### PR TITLE
Bump versions manually

### DIFF
--- a/change/@pulumi-facet-d50daff6-3854-4ce0-8c81-37ec41ca0154.json
+++ b/change/@pulumi-facet-d50daff6-3854-4ce0-8c81-37ec41ca0154.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Add treeview, treeitem, and textfield components alongside Storybook and sandbox updates.",
-  "packageName": "@pulumi/facet",
-  "email": "kimberley@pulumi.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/facet/CHANGELOG.json
+++ b/packages/facet/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@pulumi/facet",
   "entries": [
     {
+      "date": "Thu, 07 Oct 2021 18:10:43 GMT",
+      "tag": "@pulumi/facet_v0.1.0",
+      "version": "0.1.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "kimberley@pulumi.com",
+            "package": "@pulumi/facet",
+            "comment": "Add treeview, treeitem, and textfield components alongside Storybook and sandbox updates.",
+            "commit": "e5f3b6a4daed06f44847cd96e8496e380daa8a7d"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 22 Sep 2021 21:02:32 GMT",
       "tag": "@pulumi/facet_v0.0.35",
       "version": "0.0.35",

--- a/packages/facet/CHANGELOG.md
+++ b/packages/facet/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @pulumi/facet
 
-This log was last generated on Wed, 22 Sep 2021 21:02:32 GMT and should not be manually modified.
+This log was last generated on Thu, 07 Oct 2021 18:10:43 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.1.0
+
+Thu, 07 Oct 2021 18:10:43 GMT
+
+### Minor changes
+
+- Add treeview, treeitem, and textfield components alongside Storybook and sandbox updates. (kimberley@pulumi.com)
 
 ## 0.0.35
 

--- a/packages/facet/package.json
+++ b/packages/facet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pulumi/facet",
-  "version": "0.0.35",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/sites/facet/CHANGELOG.json
+++ b/sites/facet/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@pulumi/facet-website",
   "entries": [
     {
+      "date": "Thu, 07 Oct 2021 18:10:43 GMT",
+      "tag": "@pulumi/facet-website_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@pulumi/facet-website",
+            "comment": "Bump @pulumi/facet to v0.1.0",
+            "commit": "e5f3b6a4daed06f44847cd96e8496e380daa8a7d"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 22 Sep 2021 21:02:32 GMT",
       "tag": "@pulumi/facet-website_v0.0.1",
       "version": "0.0.1",

--- a/sites/facet/CHANGELOG.md
+++ b/sites/facet/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @pulumi/facet-website
 
-This log was last generated on Wed, 22 Sep 2021 21:02:32 GMT and should not be manually modified.
+This log was last generated on Thu, 07 Oct 2021 18:10:43 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.1
+
+Thu, 07 Oct 2021 18:10:43 GMT
+
+### Patches
+
+- Bump @pulumi/facet to v0.1.0
 
 ## 0.0.1
 

--- a/sites/facet/package.json
+++ b/sites/facet/package.json
@@ -18,7 +18,7 @@
     "@docusaurus/core": "2.0.0-beta.6",
     "@docusaurus/preset-classic": "2.0.0-beta.6",
     "@mdx-js/react": "^1.6.21",
-    "@pulumi/facet": "^0.0.35",
+    "@pulumi/facet": "^0.1.0",
     "@svgr/webpack": "^5.5.0",
     "clsx": "^1.1.1",
     "file-loader": "^6.2.0",

--- a/sites/sandbox/CHANGELOG.json
+++ b/sites/sandbox/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@pulumi/facet-sandbox",
   "entries": [
     {
+      "date": "Thu, 07 Oct 2021 18:10:43 GMT",
+      "tag": "@pulumi/facet-sandbox_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@pulumi/facet-sandbox",
+            "comment": "Bump @pulumi/facet to v0.1.0",
+            "commit": "e5f3b6a4daed06f44847cd96e8496e380daa8a7d"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 22 Sep 2021 21:02:32 GMT",
       "tag": "@pulumi/facet-sandbox_v0.0.1",
       "version": "0.0.1",

--- a/sites/sandbox/CHANGELOG.md
+++ b/sites/sandbox/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @pulumi/facet-sandbox
 
-This log was last generated on Wed, 22 Sep 2021 21:02:32 GMT and should not be manually modified.
+This log was last generated on Thu, 07 Oct 2021 18:10:43 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.1
+
+Thu, 07 Oct 2021 18:10:43 GMT
+
+### Patches
+
+- Bump @pulumi/facet to v0.1.0
 
 ## 0.0.1
 

--- a/sites/sandbox/package.json
+++ b/sites/sandbox/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "@pulumi/facet": "^0.0.35"
+    "@pulumi/facet": "^0.1.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^5.3.2",


### PR DESCRIPTION
Another manual `beachball bump` to account for the [last publish failure](https://github.com/pulumi/facet/actions/runs/1272127642).