### PR TITLE
Use repo-specific ESC environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
-  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-facet
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Deploy
 on:

--- a/.github/workflows/export-repo-secrets.yml
+++ b/.github/workflows/export-repo-secrets.yml
@@ -16,7 +16,7 @@ jobs:
         uses: pulumi/esc-export-secrets-action@v1
         with:
           organization: pulumi
-          org-environment: imports/github-secrets
+          org-environment: github-secrets/pulumi-facet
           exclude-secrets: EXPORT_SECRETS_PRIVATE_KEY
           github-token: ${{ steps.generate-token.outputs.token }}
           oidc-auth: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ env:
   ESC_ACTION_OIDC_AUTH: true
   ESC_ACTION_OIDC_ORGANIZATION: pulumi
   ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
-  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-facet
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Publish
 on:


### PR DESCRIPTION
This repository has repository-specific secrets that need to be migrated to ESC. These changes replace the usage of the common GHA ESC environment with the repository-specific environment.
